### PR TITLE
Install grub-mkrescue dependency with apt

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ done
 
 # Install dependencies to build palen1x
 apt-get update
-apt-get install -y --no-install-recommends wget debootstrap mtools xorriso ca-certificates curl libusb-1.0-0-dev gcc make gzip xz-utils unzip libc6-dev
+apt-get install -y --no-install-recommends wget debootstrap mtools xorriso ca-certificates curl libusb-1.0-0-dev gcc make gzip xz-utils unzip libc6-dev grub-mkrescue
 
 # Get proper files for amd64 or i686
 if [ "$ARCH" = 'amd64' ]; then


### PR DESCRIPTION
It's used at the end of the script, but not included in the `apt-get install` command. If it's not already installed on the system, the script fails.