### PR TITLE
Add rootful depreciation notice

### DIFF
--- a/scripts/palera1n_menu
+++ b/scripts/palera1n_menu
@@ -86,6 +86,8 @@ while true; do
       clear
       echo ''
       echo "# == INFORMATION =="
+      echo "# ${YELLOW}- Rootful has been depreciated, and does not support iPadOS 17.${NORMAL}"
+      echo "# ${YELLOW}- A future version of palen1x will remove fakefs/bindfs creation support.${NORMAL}"
       echo "# ${YELLOW}- If you encounter lockdownd errors make sure to${NORMAL}"
       echo "# ${YELLOW}unlock your device and replug.${NORMAL}"
       echo "# ${YELLOW}- arm64e is not supported!${NORMAL}"


### PR DESCRIPTION
Adds a notice that rootful has been depreciated and does not support iPadOS 17.

Targeted for 2.0.0b8, intended to be a precursor to #40, which is targeted for 2.0.0b9 (more on the line with regards to fakefs/bindfs creation is in that PR)