### PR TITLE
Remove fakefs/bindfs creation in palen1x

### DIFF
--- a/scripts/palera1n_menu
+++ b/scripts/palera1n_menu
@@ -86,6 +86,8 @@ while true; do
       clear
       echo ''
       echo "# == INFORMATION =="
+      echo "# ${YELLOW}- Rootful has been depreciated, and does not support iPadOS 17.${NORMAL}"
+      echo "# ${YELLOW}- palen1x no longer supports fakefs/bindfs creation.${NORMAL}"
       echo "# ${YELLOW}- If you encounter lockdownd errors make sure to${NORMAL}"
       echo "# ${YELLOW}unlock your device and replug.${NORMAL}"
       echo "# ${YELLOW}- arm64e is not supported!${NORMAL}"

--- a/scripts/palera1n_options
+++ b/scripts/palera1n_options
@@ -48,29 +48,23 @@ if [ "$jbtype" = "Rootless" ]; then
 elif [ "$jbtype" = "Rootful" ]; then
   OPTIONS="$(whiptail --separate-output --nocancel --ok-button "Select" --title "palera1n options" --checklist \
   "Press spacebar to select option, and enter to complete" 15 54 5 \
-  "1" "Create FakeFS" OFF \
-  "2" "Create BindFS" OFF \
-  "3" "Clean FakeFS" OFF \
-  "4" "Verbose" ON \
-  "5" "Safe Mode" OFF \
-  "6" "Revert Install" OFF \
-  "7" "Serial" OFF \
-  "8" "Debug" OFF 3>&1 1>&2 2>&3)"
+  "1" "Verbose" ON \
+  "2" "Safe Mode" OFF \
+  "3" "Revert Install" OFF \
+  "4" "Serial" OFF \
+  "5" "Debug" OFF 3>&1 1>&2 2>&3)"
   if [ $? = 0 ]; then
       output=""
       for OPTION in $OPTIONS; do
           case $OPTION in
-              "1") output1="-c";;
-              "2") output2="-B";;
-              "3") output3="-C";;
-              "4") output4="-V";;
-              "5") output5="-s";;
-              "6") output6="--force-revert";;
-              "7") output7="-e 'serial=3'";;
-              "8") output8="-v";;
+              "1") output1="-V";;
+              "2") output2="-s";;
+              "3") output3="--force-revert";;
+              "4") output4="-e 'serial=3'";;
+              "5") output5="-v";;
           esac
       done
-      echo "$output1 $output2 $output3 $output4 $output5 $output6 $output7 $output8" > /usr/bin/.args
+      echo "$output1 $output2 $output3 $output4 $output5" > /usr/bin/.args
       /usr/bin/palera1n_menu
   else
       echo "Cancelled"


### PR DESCRIPTION
## This PR is targeted for 2.0.0b9, and SHOULD NOT ship in 2.0.0b8

This removes the ability for average users to create a fakefs or bindfs with palen1x.

### Rationale

Require that users have to make a conscious effort (whether by using a Live Linux setup, using the CLI, or by using an older palen1x version (that we will not support)) in order to initially setup rootful, while not impacting existing rootful users or users who want to remove an already created rootful setup.

### Notes

- As iterated earlier, this **does not** remove the ability for end users to jailbreak an already existing rootful setup, nor does it remove the ability to remove an existing rootful setup. All this change does is removes the user-facing ability on the palen1x side to create a fakefs/bindfs.
- To be honest, this merge could probably allow for a simplification of the "palera1n_options" file, but I've opted not to do that as that seems a bit extra and out of scope for this PR.
- 2.0.0b7 already supports all versions that rootful will ever support (since rootful will not be supported with iPadOS 17).
- palera1n as a whole has already depreciated rootful, and palera1n and r/jailbreak have both ceased providing support for rootful palera1n issues (outside of those that come from switching away from rootful, obviously).
- Again, this is not targeted for 2.0.0b8, this is targeted for 2.0.0b9, do not merge this into 2.0.0b8 (though do merge #39 for 2.0.0b8, which introduces the applicable depreciation notices).